### PR TITLE
Make canceled_at field on Booking model nullable

### DIFF
--- a/database/factories/BookingFactory.php
+++ b/database/factories/BookingFactory.php
@@ -35,7 +35,7 @@ class BookingFactory extends Factory
             'experience_type'     => 'experience',
             'experience_id'       => 1,
             'processed_at'        => $this->faker->dateTimeBetween('+0 days', '+2 years'),
-            'canceled_at'         => $this->faker->dateTimeBetween('+0 days', '+2 years'),
+            'canceled_at'         => null,
             'creator_id'          => randomOrCreate(app('user')),
             'updater_id'          => randomOrCreate(app('user')),
         ];

--- a/database/migrations/2020_05_04_150000_create_bookings_table.php
+++ b/database/migrations/2020_05_04_150000_create_bookings_table.php
@@ -27,7 +27,7 @@ class CreateBookingsTable extends Migration
             $table->foreignIdFor(app('booking_slot'));
             $table->morphs('agent');
             $table->datetime('processed_at');
-            $table->datetime('canceled_at');
+            $table->datetime('canceled_at')->nullable();
 
             $table->foreignIdFor(app('user'), 'creator_id');
             $table->foreignIdFor(app('user'), 'updater_id');

--- a/src/Nova/Booking.php
+++ b/src/Nova/Booking.php
@@ -106,7 +106,7 @@ class Booking extends BaseResource
 
             Date::make('Processed At')->rules('required'),
 
-            Date::make('Canceled At')->rules('required'),
+            Date::make('Canceled At'),
 
             new Panel('Data Fields', $this->dataFields()),
         ]);


### PR DESCRIPTION
The `canceled_at` field on the `Booking` model is currently required. Correct me if I'm mistaken, but cancellation dates should only be added if the booking is actually canceled, correct?